### PR TITLE
feat: Add mouse navigation and text selection support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,17 @@ go 1.24.2
 
 require (
 	github.com/alecthomas/chroma/v2 v2.20.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/creack/pty v1.1.24
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
@@ -22,7 +23,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -21,6 +21,7 @@ func TestPanelIDString(t *testing.T) {
 		panel    PanelID
 		expected string
 	}{
+		{PanelNone, "None"},
 		{PanelFileTree, "FileTree"},
 		{PanelContent, "Content"},
 		{PanelMiniBuffer, "MiniBuffer"},
@@ -184,4 +185,96 @@ func TestKeyMapHelp(t *testing.T) {
 		assert.NotEmpty(t, full)
 		assert.Greater(t, len(full), 1)
 	})
+}
+
+func TestSetFocus(t *testing.T) {
+	m := New()
+	// Ensure initial focus is on file tree
+	assert.Equal(t, PanelFileTree, m.focus)
+
+	// Set focus to content
+	m = m.setFocus(PanelContent)
+	assert.Equal(t, PanelContent, m.focus)
+
+	// Verify file tree is blurred and content is focused
+	assert.False(t, m.fileTree.Focused())
+	assert.True(t, m.content.Focused())
+
+	// Set focus back to file tree
+	m = m.setFocus(PanelFileTree)
+	assert.Equal(t, PanelFileTree, m.focus)
+	assert.True(t, m.fileTree.Focused())
+	assert.False(t, m.content.Focused())
+}
+
+func TestMouseClickSetsFocus(t *testing.T) {
+	m := New()
+
+	// Set window size to initialize layout
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = updatedModel.(Model)
+	assert.True(t, m.ready)
+
+	// Initial focus should be file tree
+	assert.Equal(t, PanelFileTree, m.focus)
+
+	// Simulate click on content panel (right side)
+	// Content panel starts at x = LeftWidth
+	clickX := m.layout.LeftWidth + 10
+	clickY := 5
+	mouseMsg := tea.MouseMsg{
+		X:      clickX,
+		Y:      clickY,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}
+
+	updatedModel, _ = m.Update(mouseMsg)
+	m = updatedModel.(Model)
+
+	assert.Equal(t, PanelContent, m.focus, "expected focus to change to PanelContent after click")
+	assert.True(t, m.content.Focused(), "expected content component to be focused")
+	assert.False(t, m.fileTree.Focused(), "expected file tree component to be blurred")
+
+	// Now click back on file tree (left side)
+	mouseMsg = tea.MouseMsg{
+		X:      5, // Within file tree bounds
+		Y:      5,
+		Button: tea.MouseButtonLeft,
+		Action: tea.MouseActionPress,
+	}
+
+	updatedModel, _ = m.Update(mouseMsg)
+	m = updatedModel.(Model)
+
+	assert.Equal(t, PanelFileTree, m.focus, "expected focus to change back to PanelFileTree after click")
+	assert.True(t, m.fileTree.Focused(), "expected file tree component to be focused")
+	assert.False(t, m.content.Focused(), "expected content component to be blurred")
+}
+
+func TestPanelAtPosition(t *testing.T) {
+	m := New()
+
+	// Set window size
+	updatedModel, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+	m = updatedModel.(Model)
+
+	tests := []struct {
+		name     string
+		x, y     int
+		expected PanelID
+	}{
+		{"left panel top", 5, 5, PanelFileTree},
+		{"left panel near edge", m.layout.LeftWidth - 1, 5, PanelFileTree},
+		{"right panel start", m.layout.LeftWidth, 5, PanelContent},
+		{"right panel middle", 80, 5, PanelContent},
+		{"status bar area", 50, m.layout.MainHeight, PanelNone}, // Status bar returns PanelNone
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.panelAtPosition(tt.x, tt.y)
+			assert.Equal(t, tt.expected, result, "panelAtPosition(%d, %d)", tt.x, tt.y)
+		})
+	}
 }

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -4,14 +4,17 @@ package app
 type PanelID int
 
 const (
-	PanelFileTree PanelID = iota
-	PanelContent
-	PanelMiniBuffer
+	PanelNone     PanelID = iota // 0 = no panel (used for clicks outside panels)
+	PanelFileTree                // 1
+	PanelContent                 // 2
+	PanelMiniBuffer              // 3
 )
 
 // String returns the panel name for debugging.
 func (p PanelID) String() string {
 	switch p {
+	case PanelNone:
+		return "None"
 	case PanelFileTree:
 		return "FileTree"
 	case PanelContent:

--- a/internal/components/filetree/model.go
+++ b/internal/components/filetree/model.go
@@ -156,9 +156,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m.handleKey(msg)
 
 	case tea.MouseMsg:
-		if !m.Focused() {
-			return m, nil
-		}
+		// Always handle mouse events - app.go handles focus management
+		// This allows click-to-select even when the panel wasn't focused
 		return m.handleMouse(msg)
 	}
 

--- a/internal/selection/selection.go
+++ b/internal/selection/selection.go
@@ -1,0 +1,270 @@
+package selection
+
+import (
+	"strings"
+
+	"github.com/atotto/clipboard"
+	"github.com/avitaltamir/vibecommander/internal/theme"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Position represents a character position in the text.
+type Position struct {
+	Line   int // 0-indexed line number
+	Column int // 0-indexed column position
+}
+
+// Selection represents a text selection range.
+type Selection struct {
+	Active   bool     // Whether selection is in progress
+	Start    Position // Where selection started (anchor)
+	End      Position // Current selection end
+	Complete bool     // Whether selection is complete (mouse released)
+}
+
+// Model holds the selection state for a component.
+type Model struct {
+	Selection Selection
+	content   []string // The text content being displayed
+}
+
+// New creates a new selection model.
+func New() Model {
+	return Model{}
+}
+
+// SetContent sets the text content for selection.
+func (m *Model) SetContent(lines []string) {
+	m.content = lines
+}
+
+// StartSelection begins a new selection at the given position.
+func (m *Model) StartSelection(line, col int) {
+	m.Selection = Selection{
+		Active:   true,
+		Start:    Position{Line: line, Column: col},
+		End:      Position{Line: line, Column: col},
+		Complete: false,
+	}
+}
+
+// UpdateSelection updates the selection end position during drag.
+func (m *Model) UpdateSelection(line, col int) {
+	if !m.Selection.Active {
+		return
+	}
+	m.Selection.End = Position{Line: line, Column: col}
+}
+
+// EndSelection marks the selection as complete.
+func (m *Model) EndSelection() {
+	if !m.Selection.Active {
+		return
+	}
+	m.Selection.Complete = true
+	m.Selection.Active = false
+}
+
+// ClearSelection clears any active selection.
+func (m *Model) ClearSelection() {
+	m.Selection = Selection{}
+}
+
+// HasSelection returns true if there's a valid selection.
+func (m Model) HasSelection() bool {
+	return m.Selection.Complete && !m.positionsEqual(m.Selection.Start, m.Selection.End)
+}
+
+// GetSelectedText returns the selected text from the content.
+func (m Model) GetSelectedText() string {
+	if !m.HasSelection() {
+		return ""
+	}
+
+	start, end := m.normalizeRange()
+	if len(m.content) == 0 {
+		return ""
+	}
+
+	// Clamp to valid range
+	if start.Line < 0 {
+		start.Line = 0
+	}
+	if start.Line >= len(m.content) {
+		return ""
+	}
+	if end.Line >= len(m.content) {
+		end.Line = len(m.content) - 1
+		end.Column = len(m.content[end.Line])
+	}
+
+	// Single line selection
+	if start.Line == end.Line {
+		line := m.content[start.Line]
+		startCol := clamp(start.Column, 0, len(line))
+		endCol := clamp(end.Column, 0, len(line))
+		if startCol > endCol {
+			startCol, endCol = endCol, startCol
+		}
+		return line[startCol:endCol]
+	}
+
+	// Multi-line selection
+	var result strings.Builder
+
+	// First line (from start column to end)
+	firstLine := m.content[start.Line]
+	startCol := clamp(start.Column, 0, len(firstLine))
+	result.WriteString(firstLine[startCol:])
+	result.WriteString("\n")
+
+	// Middle lines (complete lines)
+	for i := start.Line + 1; i < end.Line; i++ {
+		result.WriteString(m.content[i])
+		result.WriteString("\n")
+	}
+
+	// Last line (from start to end column)
+	lastLine := m.content[end.Line]
+	endCol := clamp(end.Column, 0, len(lastLine))
+	result.WriteString(lastLine[:endCol])
+
+	return result.String()
+}
+
+// CopyToClipboard copies the selected text to the system clipboard.
+func (m Model) CopyToClipboard() error {
+	text := m.GetSelectedText()
+	if text == "" {
+		return nil
+	}
+	return clipboard.WriteAll(text)
+}
+
+// IsSelected returns true if the character at (line, col) is within the selection.
+func (m Model) IsSelected(line, col int) bool {
+	if !m.Selection.Complete && !m.Selection.Active {
+		return false
+	}
+
+	start, end := m.normalizeRange()
+
+	// Before selection start
+	if line < start.Line {
+		return false
+	}
+	if line == start.Line && col < start.Column {
+		return false
+	}
+
+	// After selection end
+	if line > end.Line {
+		return false
+	}
+	if line == end.Line && col >= end.Column {
+		return false
+	}
+
+	return true
+}
+
+// normalizeRange returns start and end positions in order (start < end).
+func (m Model) normalizeRange() (Position, Position) {
+	start := m.Selection.Start
+	end := m.Selection.End
+
+	// Ensure start comes before end
+	if start.Line > end.Line || (start.Line == end.Line && start.Column > end.Column) {
+		start, end = end, start
+	}
+
+	return start, end
+}
+
+// positionsEqual returns true if two positions are the same.
+func (m Model) positionsEqual(a, b Position) bool {
+	return a.Line == b.Line && a.Column == b.Column
+}
+
+// IsCopyKey returns true if the key message is a copy command.
+// On macOS, Cmd+C is intercepted by the terminal emulator before reaching the app,
+// so we support multiple key bindings for copy:
+// - Ctrl+C: Standard terminal copy (when text is selected; otherwise SIGINT)
+// - y: Vim-style yank
+// - Ctrl+Y: Alternative copy binding
+func IsCopyKey(key string) bool {
+	switch key {
+	case "ctrl+c", "y", "ctrl+y":
+		return true
+	default:
+		return false
+	}
+}
+
+// SelectionStyle returns the lipgloss style for selected text.
+func SelectionStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(theme.BgSelection).
+		Foreground(theme.TextSelection)
+}
+
+// RenderWithSelection renders a line of text with selection highlighting.
+// The offset parameter adjusts for line numbers or other prefixes.
+func RenderWithSelection(line string, lineNum int, sel *Model, offset int) string {
+	if sel == nil || (!sel.Selection.Active && !sel.Selection.Complete) {
+		return line
+	}
+
+	// Check if any part of this line is selected
+	start, end := sel.normalizeRange()
+	if lineNum < start.Line || lineNum > end.Line {
+		return line
+	}
+
+	// Determine selection bounds for this line
+	selStart := 0
+	selEnd := len(line)
+
+	if lineNum == start.Line {
+		selStart = start.Column - offset
+	}
+	if lineNum == end.Line {
+		selEnd = end.Column - offset
+	}
+
+	// Clamp to valid range
+	if selStart < 0 {
+		selStart = 0
+	}
+	if selEnd > len(line) {
+		selEnd = len(line)
+	}
+	if selStart >= selEnd {
+		return line
+	}
+
+	// Build result with selection highlighting
+	style := SelectionStyle()
+	var result strings.Builder
+
+	if selStart > 0 {
+		result.WriteString(line[:selStart])
+	}
+	result.WriteString(style.Render(line[selStart:selEnd]))
+	if selEnd < len(line) {
+		result.WriteString(line[selEnd:])
+	}
+
+	return result.String()
+}
+
+// clamp restricts v to the range [min, max].
+func clamp(v, min, max int) int {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}

--- a/internal/selection/selection_test.go
+++ b/internal/selection/selection_test.go
@@ -1,0 +1,211 @@
+package selection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	m := New()
+	assert.False(t, m.HasSelection())
+	assert.Equal(t, "", m.GetSelectedText())
+}
+
+func TestStartSelection(t *testing.T) {
+	m := New()
+	m.StartSelection(5, 10)
+
+	assert.True(t, m.Selection.Active)
+	assert.Equal(t, 5, m.Selection.Start.Line)
+	assert.Equal(t, 10, m.Selection.Start.Column)
+	assert.Equal(t, 5, m.Selection.End.Line)
+	assert.Equal(t, 10, m.Selection.End.Column)
+	assert.False(t, m.Selection.Complete)
+}
+
+func TestUpdateSelection(t *testing.T) {
+	m := New()
+	m.StartSelection(5, 10)
+	m.UpdateSelection(7, 15)
+
+	assert.True(t, m.Selection.Active)
+	assert.Equal(t, 5, m.Selection.Start.Line)
+	assert.Equal(t, 10, m.Selection.Start.Column)
+	assert.Equal(t, 7, m.Selection.End.Line)
+	assert.Equal(t, 15, m.Selection.End.Column)
+}
+
+func TestUpdateSelectionNotActive(t *testing.T) {
+	m := New()
+	// Try to update without starting selection
+	m.UpdateSelection(7, 15)
+
+	// Should not change anything
+	assert.False(t, m.Selection.Active)
+	assert.Equal(t, 0, m.Selection.End.Line)
+	assert.Equal(t, 0, m.Selection.End.Column)
+}
+
+func TestEndSelection(t *testing.T) {
+	m := New()
+	m.StartSelection(5, 10)
+	m.UpdateSelection(7, 15)
+	m.EndSelection()
+
+	assert.False(t, m.Selection.Active)
+	assert.True(t, m.Selection.Complete)
+}
+
+func TestEndSelectionNotActive(t *testing.T) {
+	m := New()
+	// Try to end without starting
+	m.EndSelection()
+
+	assert.False(t, m.Selection.Active)
+	assert.False(t, m.Selection.Complete)
+}
+
+func TestClearSelection(t *testing.T) {
+	m := New()
+	m.StartSelection(5, 10)
+	m.UpdateSelection(7, 15)
+	m.EndSelection()
+	m.ClearSelection()
+
+	assert.False(t, m.HasSelection())
+	assert.False(t, m.Selection.Active)
+	assert.False(t, m.Selection.Complete)
+}
+
+func TestHasSelection(t *testing.T) {
+	m := New()
+
+	// No selection initially
+	assert.False(t, m.HasSelection())
+
+	// Active but not complete
+	m.StartSelection(5, 10)
+	assert.False(t, m.HasSelection())
+
+	// Complete selection
+	m.UpdateSelection(7, 15)
+	m.EndSelection()
+	assert.True(t, m.HasSelection())
+
+	// Same start and end (no actual selection)
+	m2 := New()
+	m2.StartSelection(5, 10)
+	m2.EndSelection()
+	assert.False(t, m2.HasSelection())
+}
+
+func TestGetSelectedTextSingleLine(t *testing.T) {
+	m := New()
+	m.SetContent([]string{
+		"Hello, World!",
+		"This is line 2",
+		"And line 3",
+	})
+
+	m.StartSelection(0, 7)
+	m.UpdateSelection(0, 12)
+	m.EndSelection()
+
+	assert.Equal(t, "World", m.GetSelectedText())
+}
+
+func TestGetSelectedTextMultiLine(t *testing.T) {
+	m := New()
+	m.SetContent([]string{
+		"First line",
+		"Second line",
+		"Third line",
+	})
+
+	m.StartSelection(0, 6)
+	m.UpdateSelection(2, 5)
+	m.EndSelection()
+
+	expected := "line\nSecond line\nThird"
+	assert.Equal(t, expected, m.GetSelectedText())
+}
+
+func TestGetSelectedTextReverseSelection(t *testing.T) {
+	m := New()
+	m.SetContent([]string{
+		"Hello, World!",
+	})
+
+	// Select backwards (end before start)
+	m.StartSelection(0, 12)
+	m.UpdateSelection(0, 7)
+	m.EndSelection()
+
+	assert.Equal(t, "World", m.GetSelectedText())
+}
+
+func TestGetSelectedTextEmpty(t *testing.T) {
+	m := New()
+	m.SetContent([]string{})
+
+	// No selection
+	assert.Equal(t, "", m.GetSelectedText())
+
+	// Selection on empty content
+	m.StartSelection(0, 0)
+	m.UpdateSelection(0, 5)
+	m.EndSelection()
+	assert.Equal(t, "", m.GetSelectedText())
+}
+
+func TestIsSelected(t *testing.T) {
+	m := New()
+	m.SetContent([]string{
+		"Line 0",
+		"Line 1",
+		"Line 2",
+	})
+
+	m.StartSelection(0, 3)
+	m.UpdateSelection(2, 2)
+	m.EndSelection()
+
+	// Before selection start
+	assert.False(t, m.IsSelected(0, 0))
+	assert.False(t, m.IsSelected(0, 2))
+
+	// Within selection
+	assert.True(t, m.IsSelected(0, 3))
+	assert.True(t, m.IsSelected(0, 5))
+	assert.True(t, m.IsSelected(1, 0))
+	assert.True(t, m.IsSelected(1, 5))
+	assert.True(t, m.IsSelected(2, 0))
+	assert.True(t, m.IsSelected(2, 1))
+
+	// At or after selection end
+	assert.False(t, m.IsSelected(2, 2))
+	assert.False(t, m.IsSelected(2, 5))
+	assert.False(t, m.IsSelected(3, 0))
+}
+
+func TestIsCopyKey(t *testing.T) {
+	// Copy keys should be recognized
+	assert.True(t, IsCopyKey("ctrl+c"))
+	assert.True(t, IsCopyKey("y"))       // Vim-style yank
+	assert.True(t, IsCopyKey("ctrl+y"))  // Alternative binding
+
+	// Other keys should not be recognized
+	assert.False(t, IsCopyKey("c"))
+	assert.False(t, IsCopyKey("ctrl+v"))
+	assert.False(t, IsCopyKey("ctrl+x"))
+	assert.False(t, IsCopyKey("enter"))
+}
+
+func TestClamp(t *testing.T) {
+	assert.Equal(t, 5, clamp(5, 0, 10))
+	assert.Equal(t, 0, clamp(-5, 0, 10))
+	assert.Equal(t, 10, clamp(15, 0, 10))
+	assert.Equal(t, 0, clamp(0, 0, 10))
+	assert.Equal(t, 10, clamp(10, 0, 10))
+}

--- a/internal/theme/colors.go
+++ b/internal/theme/colors.go
@@ -36,6 +36,12 @@ var (
 	BgDiffHunk    = lipgloss.Color("#1A1A3E") // Hunk header background
 )
 
+// Selection Colors - Text selection highlighting
+var (
+	BgSelection   = lipgloss.Color("#3D2D5E") // Selection background
+	TextSelection = lipgloss.Color("#FFFFFF") // Selected text color
+)
+
 // Semantic Color Aliases - Use these in components for consistency
 var (
 	ColorPrimary   = MagentaBlaze


### PR DESCRIPTION
## Summary

- Add mouse click to focus panes (file tree, content, mini buffer)
- Implement text selection with mouse drag in content viewer and terminal
- Add selection package for shared selection state management
- Support Ctrl+C, y (vim yank), or Ctrl+Y to copy selected text to clipboard
- Fix PanelNone constant to properly handle mouse click focus on file tree panel
- Add selection colors to theme (BgSelection, TextSelection)
- Clear selection with Escape key
- Selection is visually highlighted using reverse video in terminal
- Comprehensive unit tests for selection and mouse focus functionality

## Test plan

- [ ] Click on file tree panel - border should highlight to show focus
- [ ] Click on content panel - border should highlight to show focus
- [ ] Click and drag in content viewer to select text - selection should be visible
- [ ] Press `y`, `Ctrl+C`, or `Ctrl+Y` with text selected - text should copy to clipboard
- [ ] Press `Escape` with text selected - selection should clear
- [ ] Run `go test ./...` - all tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)